### PR TITLE
Deprecate WebRequest and related classes.

### DIFF
--- a/src/main/java/me/geso/webscrew/Parameters.java
+++ b/src/main/java/me/geso/webscrew/Parameters.java
@@ -3,6 +3,10 @@ package me.geso.webscrew;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * There is no reason to use this.
+ */
+@Deprecated
 public interface Parameters {
 
 	public Optional<String> getFirst(final String name);

--- a/src/main/java/me/geso/webscrew/request/WebRequest.java
+++ b/src/main/java/me/geso/webscrew/request/WebRequest.java
@@ -11,6 +11,7 @@ import javax.servlet.http.Cookie;
 
 import me.geso.webscrew.Parameters;
 
+@Deprecated
 public interface WebRequest {
 
 	/**

--- a/src/main/java/me/geso/webscrew/request/WebRequestUpload.java
+++ b/src/main/java/me/geso/webscrew/request/WebRequestUpload.java
@@ -3,11 +3,9 @@ package me.geso.webscrew.request;
 import java.io.InputStream;
 
 /**
- * Interface for uploaded file in HTTP request.
- * 
- * @author tokuhirom
- *
+ * Use Part directly.
  */
+@Deprecated
 public interface WebRequestUpload {
 
 	/**

--- a/src/main/java/me/geso/webscrew/request/impl/DefaultParameters.java
+++ b/src/main/java/me/geso/webscrew/request/impl/DefaultParameters.java
@@ -11,11 +11,9 @@ import java.util.Optional;
 import me.geso.webscrew.Parameters;
 
 /**
- * The class represents paremeters.
- * 
- * @author tokuhirom
- *
+ * There is no reason to use this.
  */
+@Deprecated
 public class DefaultParameters implements Parameters {
 	@Override
 	public String toString() {

--- a/src/main/java/me/geso/webscrew/request/impl/DefaultWebRequest.java
+++ b/src/main/java/me/geso/webscrew/request/impl/DefaultWebRequest.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.IOUtils;
  *
  */
 @ToString
+@Deprecated
 public class DefaultWebRequest implements WebRequest {
 	private final HttpServletRequest servletRequest;
 	private Map<String, List<WebRequestUpload>> uploads;

--- a/src/main/java/me/geso/webscrew/request/impl/DefaultWebRequestUpload.java
+++ b/src/main/java/me/geso/webscrew/request/impl/DefaultWebRequestUpload.java
@@ -8,6 +8,7 @@ import me.geso.webscrew.request.WebRequestUpload;
 
 import org.apache.commons.fileupload.FileItem;
 
+@Deprecated
 public class DefaultWebRequestUpload implements WebRequestUpload {
 
 	private final FileItem fileItem;

--- a/src/main/java/me/geso/webscrew/request/impl/UrlEncoded.java
+++ b/src/main/java/me/geso/webscrew/request/impl/UrlEncoded.java
@@ -6,6 +6,11 @@ import java.net.URLDecoder;
 import lombok.NonNull;
 import me.geso.webscrew.Parameters;
 
+/**
+ * Interface is not good. The class like this should use standard collection instead of DefaultParameters.
+ * If you want to use this, you can move this class to different package.
+ */
+@Deprecated
 class UrlEncoded {
 	static Parameters parseQueryString(String queryString,
 			@NonNull String encoding) throws UnsupportedEncodingException {

--- a/src/test/java/me/geso/webscrew/request/impl/DefaultParametersTest.java
+++ b/src/test/java/me/geso/webscrew/request/impl/DefaultParametersTest.java
@@ -9,6 +9,7 @@ import me.geso.webscrew.Parameters;
 
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class DefaultParametersTest {
 
 	@Test

--- a/src/test/java/me/geso/webscrew/request/impl/DefaultWebRequestTest.java
+++ b/src/test/java/me/geso/webscrew/request/impl/DefaultWebRequestTest.java
@@ -11,6 +11,7 @@ import me.geso.webscrew.Utils;
 
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class DefaultWebRequestTest {
 
 	@Test


### PR DESCRIPTION
Current implementation is completely broken. It's not compatible with Servlet filters that calls  `HttpServletRequest#getParameter(String)`.

Once a filter calls `HttpServletRequest#getParameter(String)`, it eats content body from `HttpServletRequest#getInputStream()`. Then, the Servlet can't read parameters...

Servlet application shouldn't try to parse the application/x-www-urlencoded and multipart/form-data!
